### PR TITLE
MOO-394, MOO-395:Implement conditions widget to show diagnoses

### DIFF
--- a/api/src/main/java/org/openmrs/module/msfcore/MSFCoreActivator.java
+++ b/api/src/main/java/org/openmrs/module/msfcore/MSFCoreActivator.java
@@ -67,8 +67,7 @@ public class MSFCoreActivator extends BaseModuleActivator {
         Context.getService(AppFrameworkService.class).disableApp(MSFCoreConfig.REGISTRATION_APP_EXTENSION_ID);
         Context.getService(AppFrameworkService.class).enableApp(MSFCoreConfig.MSF_REGISTRATION_APP_EXTENSION_ID);
 
-        // disable the default find patient app to provide one which allows
-        // searching for patients at the footer of the search for patients page
+        // disable the default find patient app to provide one which allows searching for patients at the footer of the search for patients page
         Context.getService(AppFrameworkService.class).disableApp(MSFCoreConfig.SEARCH_APP_EXTENSION_ID);
         Context.getService(AppFrameworkService.class).enableApp(MSFCoreConfig.MSF_SEARCH_APP_EXTENSION_ID);
 

--- a/api/src/main/java/org/openmrs/module/msfcore/MSFCoreActivator.java
+++ b/api/src/main/java/org/openmrs/module/msfcore/MSFCoreActivator.java
@@ -108,7 +108,7 @@ public class MSFCoreActivator extends BaseModuleActivator {
         installMsfForms();
 
         log.info("Disabling diagnoses");
-        Context.getService(AppFrameworkService.class).disableApp(MSFCoreConfig.WGT_APP_DIAGNOSES_ID);
+        Context.getService(AppFrameworkService.class).disableApp(MSFCoreConfig.DIAGNOSES_APP_EXTENSION_ID);
     }
 
     private void removeMSFMeta() {
@@ -152,7 +152,7 @@ public class MSFCoreActivator extends BaseModuleActivator {
         Context.getService(AppFrameworkService.class).disableApp(MSFCoreConfig.MSF_SEARCH_APP_EXTENSION_ID);
 
         log.info("Enabling diagnoses");
-        Context.getService(AppFrameworkService.class).enableApp(MSFCoreConfig.WGT_APP_DIAGNOSES_ID);
+        Context.getService(AppFrameworkService.class).enableApp(MSFCoreConfig.DIAGNOSES_APP_EXTENSION_ID);
     }
 
     /**

--- a/api/src/main/java/org/openmrs/module/msfcore/MSFCoreActivator.java
+++ b/api/src/main/java/org/openmrs/module/msfcore/MSFCoreActivator.java
@@ -67,7 +67,8 @@ public class MSFCoreActivator extends BaseModuleActivator {
         Context.getService(AppFrameworkService.class).disableApp(MSFCoreConfig.REGISTRATION_APP_EXTENSION_ID);
         Context.getService(AppFrameworkService.class).enableApp(MSFCoreConfig.MSF_REGISTRATION_APP_EXTENSION_ID);
 
-        // disable the default find patient app to provide one which allows searching for patients at the footer of the search for patients page
+        // disable the default find patient app to provide one which allows
+        // searching for patients at the footer of the search for patients page
         Context.getService(AppFrameworkService.class).disableApp(MSFCoreConfig.SEARCH_APP_EXTENSION_ID);
         Context.getService(AppFrameworkService.class).enableApp(MSFCoreConfig.MSF_SEARCH_APP_EXTENSION_ID);
 
@@ -106,6 +107,9 @@ public class MSFCoreActivator extends BaseModuleActivator {
 
         log.info("Installing MSF Forms");
         installMsfForms();
+
+        log.info("Disabling diagnoses");
+        Context.getService(AppFrameworkService.class).disableApp(MSFCoreConfig.WGT_APP_DIAGNOSES_ID);
     }
 
     private void removeMSFMeta() {

--- a/api/src/main/java/org/openmrs/module/msfcore/MSFCoreActivator.java
+++ b/api/src/main/java/org/openmrs/module/msfcore/MSFCoreActivator.java
@@ -150,6 +150,9 @@ public class MSFCoreActivator extends BaseModuleActivator {
         // disable the MSF find patient app and enable the default core apps one
         Context.getService(AppFrameworkService.class).enableApp(MSFCoreConfig.SEARCH_APP_EXTENSION_ID);
         Context.getService(AppFrameworkService.class).disableApp(MSFCoreConfig.MSF_SEARCH_APP_EXTENSION_ID);
+
+        log.info("Enabling diagnoses");
+        Context.getService(AppFrameworkService.class).enableApp(MSFCoreConfig.WGT_APP_DIAGNOSES_ID);
     }
 
     /**

--- a/api/src/main/java/org/openmrs/module/msfcore/MSFCoreConfig.java
+++ b/api/src/main/java/org/openmrs/module/msfcore/MSFCoreConfig.java
@@ -22,6 +22,7 @@ public class MSFCoreConfig {
 
     public final static String REGISTRATION_APP_EXTENSION_ID = "referenceapplication.registrationapp.registerPatient";
     public final static String SEARCH_APP_EXTENSION_ID = "coreapps.findPatient";
+    public final static String DIAGNOSES_APP_EXTENSION_ID = "coreapps.diagnoses";
 
     public final static String MSF_REGISTRATION_APP_EXTENSION_ID = "msfcore.registrationapp";
     public final static String MSF_SEARCH_APP_EXTENSION_ID = "msfcore.findPatient";
@@ -352,5 +353,4 @@ public class MSFCoreConfig {
 
     public final static String URL_POSTFIX_OPTIONSETS = "/api/optionSets.json?paging=false&fields=name,options[:code,name]";
 
-    public final static String WGT_APP_DIAGNOSES_ID = "coreapps.diagnoses";
 }

--- a/api/src/main/java/org/openmrs/module/msfcore/MSFCoreConfig.java
+++ b/api/src/main/java/org/openmrs/module/msfcore/MSFCoreConfig.java
@@ -351,4 +351,6 @@ public class MSFCoreConfig {
     public final static String GP_SYNC_WITH_DHIS2 = "msfcore.syncWithDHISOnPatientRegistration";
 
     public final static String URL_POSTFIX_OPTIONSETS = "/api/optionSets.json?paging=false&fields=name,options[:code,name]";
+
+    public final static String WGT_APP_DIAGNOSES_ID = "coreapps.diagnoses";
 }

--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -97,4 +97,10 @@
 			<column name="uuid" value="fc339d1c-b11b-11e8-96f8-529269fb1459" />
 		</insert>
 	</changeSet>
+	
+	<changeSet id="20180927-0910" author="guimino"> 
+		<comment>setting the default locale to en using the language code(ISO 639-1)</comment> 
+		<update tableName="global_property"><column name="property_value" value="en"/><where> property = 'default_locale'</where></update> 
+	</changeSet>
+	
 </databaseChangeLog>

--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -98,9 +98,4 @@
 		</insert>
 	</changeSet>
 	
-	<changeSet id="20180927-0910" author="guimino"> 
-		<comment>setting the default locale to en using the language code(ISO 639-1)</comment> 
-		<update tableName="global_property"><column name="property_value" value="en"/><where> property = 'default_locale'</where></update> 
-	</changeSet>
-	
 </databaseChangeLog>


### PR DESCRIPTION
- Remove DIAGNOSES widget in the Patient dashboard

- Added a changeset  to set the default locale to **'en'** (ISO 639-1),  this will resolve the problem in searching (concept, and other resources) using default locale. 
